### PR TITLE
Bump httpclient from 4.5.7 to 4.5.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -170,7 +170,7 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
-			<version>4.5.7</version>
+			<version>4.5.13</version>
 		</dependency>
 	</dependencies>
 	<properties>


### PR DESCRIPTION
Bumps httpclient from 4.5.7 to 4.5.13.

---
updated-dependencies:
- dependency-name: org.apache.httpcomponents:httpclient dependency-type: direct:production ...